### PR TITLE
feat: Add image generator page

### DIFF
--- a/frontUI/app/image-generator/page.tsx
+++ b/frontUI/app/image-generator/page.tsx
@@ -1,0 +1,11 @@
+import { ImageGeneratorForm } from "@/components/ImageGeneratorForm";
+import { title } from "@/components/primitives";
+
+export default function ImageGeneratorPage() {
+  return (
+    <div>
+      <h1 className={title()}>Image Generator</h1>
+      <ImageGeneratorForm />
+    </div>
+  );
+}

--- a/frontUI/components/ImageGeneratorForm.tsx
+++ b/frontUI/components/ImageGeneratorForm.tsx
@@ -29,9 +29,11 @@ export const ImageGeneratorForm = () => {
         throw new Error("Failed to generate image.");
       }
 
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      setImageUrl(url);
+      const data = await response.json();
+      if (!data.image) {
+        throw new Error("No image URL found in the response.");
+      }
+      setImageUrl(data.image);
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message);

--- a/frontUI/components/ImageGeneratorForm.tsx
+++ b/frontUI/components/ImageGeneratorForm.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@heroui/button";
+import { Input } from "@heroui/input";
+
+export const ImageGeneratorForm = () => {
+  const [prompt, setPrompt] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setImageUrl("");
+
+    try {
+      const response = await fetch("http://localhost:4000/api/images/generate", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ prompt }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to generate image.");
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      setImageUrl(url);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("An unknown error occurred.")
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center w-full max-w-lg mx-auto p-4">
+      <form onSubmit={handleSubmit} className="w-full flex flex-col gap-4">
+        <Input
+          type="text"
+          label="Image Prompt"
+          placeholder="Enter a description for your image"
+          value={prompt}
+          onValueChange={setPrompt}
+          fullWidth
+        />
+        <Button type="submit" color="primary" disabled={loading} isLoading={loading}>
+          {loading ? "Generating..." : "Generate Image"}
+        </Button>
+      </form>
+
+      {error && <div className="mt-4 text-red-500">{error}</div>}
+
+      <div className="mt-8 w-full flex justify-center">
+        {imageUrl && (
+          <div className="w-full max-w-md">
+            <h3 className="text-lg font-semibold text-center mb-4">Generated Image:</h3>
+            <img src={imageUrl} alt="Generated" className="w-full h-auto rounded-lg shadow-lg" />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontUI/config/site.ts
+++ b/frontUI/config/site.ts
@@ -24,6 +24,10 @@ export const siteConfig = {
       label: "About",
       href: "/about",
     },
+    {
+      label: "Image Generator",
+      href: "/image-generator",
+    },
   ],
   navMenuItems: [
     {


### PR DESCRIPTION
This commit introduces a new page for generating images.

- Creates a reusable `ImageGeneratorForm` component that handles the form submission, loading, and error states.
- The form sends a POST request to `http://localhost:4000/api/images/generate` and displays the returned image.
- Adds a new page at `/image-generator` to host the form.
- Updates the navigation bar to include a link to the new page.